### PR TITLE
feat: rewrite createFixedExpense with period-aware recurring expenses

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -989,14 +989,14 @@
             "deprecationReason": null
           },
           {
-            "name": "category",
+            "name": "categoryId",
             "description": null,
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "ENUM",
-                "name": "Category",
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -1036,16 +1036,20 @@
             "name": "frequency",
             "description": null,
             "type": {
-              "kind": "ENUM",
-              "name": "FixedExpenseFrequency",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "FixedExpenseFrequency",
+                "ofType": null
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "numberOfMonthsOrWeeks",
+            "name": "numberOfRepetitions",
             "description": null,
             "type": {
               "kind": "NON_NULL",
@@ -1069,6 +1073,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Date",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "subCategoryId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },

--- a/schema.graphql
+++ b/schema.graphql
@@ -274,9 +274,10 @@ input CreateFixedExpenseInput {
   total: Float!
   payBefore: Date!
   comment: String
-  category: Category!
-  numberOfMonthsOrWeeks: Int!
-  frequency: FixedExpenseFrequency
+  categoryId: String!
+  subCategoryId: String!
+  numberOfRepetitions: Int!
+  frequency: FixedExpenseFrequency!
 }
 
 input UpdateExpenseInput {

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -136,12 +136,13 @@ export type CreateExpenseInput = {
 
 export type CreateFixedExpenseInput = {
   cardId?: InputMaybe<Scalars['ID']['input']>;
-  category: Category;
+  categoryId: Scalars['String']['input'];
   comment?: InputMaybe<Scalars['String']['input']>;
   concept: Scalars['String']['input'];
-  frequency?: InputMaybe<FixedExpenseFrequency>;
-  numberOfMonthsOrWeeks: Scalars['Int']['input'];
+  frequency: FixedExpenseFrequency;
+  numberOfRepetitions: Scalars['Int']['input'];
   payBefore: Scalars['Date']['input'];
+  subCategoryId: Scalars['String']['input'];
   total: Scalars['Float']['input'];
 };
 

--- a/src/repository/expense-repository.ts
+++ b/src/repository/expense-repository.ts
@@ -20,13 +20,19 @@ export class ExpenseRepository {
     this.sequelizeClient = sequelizeClient;
   }
 
-  async createExpense(input: ExpenseInput) {
-    const expense = await Expense.create({
-      userId: this.userId,
-      ...input,
-    });
+  async createExpense(
+    input: ExpenseInput,
+    options: { transaction?: Transaction } = {}
+  ) {
+    const expense = await Expense.create(
+      {
+        userId: this.userId,
+        ...input,
+      },
+      { transaction: options.transaction }
+    );
 
-    return await this.getExpenseByPK(expense.id);
+    return await this.getExpenseByPK(expense.id, options);
   }
 
   async updateExpense(

--- a/src/repository/period-repository.ts
+++ b/src/repository/period-repository.ts
@@ -1,5 +1,4 @@
 import {
-  CreateOptions,
   Op,
   Sequelize,
   Transaction,
@@ -14,10 +13,11 @@ export type PeriodInputs = {
   id?: string;
 };
 
+export const FORTNIGHTLY_NUMBER_OF_DAYS = 13;
+
 export class PeriodRepository {
   userId: string;
   sequelize: Sequelize;
-  FORTNIGHTLY_NUMBER_OF_DAYS = 13;
 
   constructor(userId: string, sequelize: Sequelize) {
     this.userId = userId;
@@ -64,62 +64,86 @@ export class PeriodRepository {
     }
   }
 
-  async createPeriod(startDate: Date, options?: CreateOptions) {
+  async createPeriod(
+    startDate: Date,
+    options: { transaction?: Transaction } = {}
+  ) {
     const endDate = new Date(startDate);
-    // TODO create table for user settings where the period type can be stored
-    // and retrieved dynamically based on user preferences.
-    // For now, we will use a hardcoded value for the period type.
-    // Default value for now, this value should come from user settings or input
     const periodType: 'WEEKLY' | 'FORTNIGHTLY' | 'MONTHLY' = 'FORTNIGHTLY';
 
     switch (periodType) {
-    // case 'WEEKLY':
-    //   endDate.setDate(endDate.getDate() + 7);
-    //   break;
     case 'FORTNIGHTLY':
-      endDate.setDate(endDate.getDate() + this.FORTNIGHTLY_NUMBER_OF_DAYS);
+      endDate.setDate(endDate.getDate() + FORTNIGHTLY_NUMBER_OF_DAYS);
       break;
-      // case 'MONTHLY':
-      //   endDate.setMonth(endDate.getMonth() + 1);
-      //   break;
     default:
       throw new Error('Invalid period type');
     }
 
-    const period = await Period.findOne({
+    const existing = await Period.findOne({
       where: {
         userId: this.userId,
         type: periodType,
         startDate: { [Op.lte]: startDate },
         endDate: { [Op.gte]: startDate },
       },
+      transaction: options.transaction,
     });
 
-    if (period) {
+    if (existing) {
       logger.info(
-        `Found existing period: ${period.id} ${startDate} to ${endDate}`
+        `Found existing period: ${existing.id} ${startDate} to ${endDate}`
       );
-      if (startDate > period.startDate) {
-        await period.update({ startDate, endDate });
+      if (startDate > existing.startDate) {
+        await existing.update(
+          { startDate, endDate },
+          { transaction: options.transaction }
+        );
       }
-      return period.reload();
+      return existing.reload({ transaction: options.transaction });
     }
 
-    const result = await Period.create(
-      {
+    const latestBefore = await Period.findOne({
+      where: {
         userId: this.userId,
         type: periodType,
-        startDate,
-        endDate,
+        endDate: { [Op.lt]: startDate },
       },
-      options
-    );
+      order: [['endDate', 'DESC']],
+      transaction: options.transaction,
+    });
 
-    logger.info(
-      `Period created: ${
-        result.id
-      } - ${startDate.toISOString()} to ${endDate.toISOString()}`
-    );
+    let chainStart: Date;
+    if (latestBefore) {
+      chainStart = new Date(latestBefore.endDate);
+      chainStart.setDate(chainStart.getDate() + 1);
+    } else {
+      chainStart = startDate;
+    }
+
+    let result: Period;
+    let currentStart = chainStart;
+
+    while (currentStart <= startDate) {
+      const currentEnd = new Date(currentStart);
+      currentEnd.setDate(currentEnd.getDate() + FORTNIGHTLY_NUMBER_OF_DAYS);
+
+      result = await Period.create(
+        {
+          userId: this.userId,
+          type: periodType,
+          startDate: currentStart,
+          endDate: currentEnd,
+        },
+        { transaction: options.transaction }
+      );
+
+      logger.info(
+        `Period created: ${result.id} - ${currentStart.toISOString()} to ${currentEnd.toISOString()}`
+      );
+
+      currentStart = new Date(currentEnd);
+      currentStart.setDate(currentStart.getDate() + 1);
+    }
 
     return result;
   }

--- a/src/resolvers/mutation/expenses/create-fixed-expense.ts
+++ b/src/resolvers/mutation/expenses/create-fixed-expense.ts
@@ -1,90 +1,23 @@
-import {
-  addDays,
-  addMonths,
-  differenceInMonths,
-  differenceInWeeks,
-} from 'date-fns';
-import {
-  adaptExpensesWithCard,
-  categoryAdapter,
-} from '../../../adapters/index.js';
-import {
-  FixedExpenseFrequency,
-  MutationResolvers,
-} from '../../../generated/graphql.js';
-import { logger } from '../../../logger.js';
-import { Card, Expense } from '../../../models/index.js';
+import { adaptExpensesDTOInput } from '../../../adapters/income-adapter.js';
+import { MutationResolvers } from '../../../generated/graphql.js';
+import { ExpensesService } from '../../../service/expenses-service.js';
 import { Date as CustomDate } from '../../../scalars/date.js';
-import {
-  calculateNumberOfBiWeeklyWeeks,
-  calculateNumberOfMonthWeeks,
-} from '../../../utils/date-utils.js';
 
 export const createFixedExpense: MutationResolvers['createFixedExpense'] =
-  async (_, { input }, context) => {
-    const {
-      cardId,
-      concept,
-      total,
-      comment,
-      payBefore,
-      category,
-      numberOfMonthsOrWeeks,
-      frequency,
-    } = input;
+  async (_, { input }, { user: { userId }, sequelizeClient }) => {
+    const expenseService = new ExpensesService(userId, sequelizeClient);
 
-    const {
-      user: { userId },
-    } = context;
+    const expenses = await expenseService.createFixedExpenses({
+      concept: input.concept,
+      total: input.total,
+      cardId: input.cardId,
+      payBefore: CustomDate.parseValue(input.payBefore),
+      comment: input.comment,
+      categoryId: input.categoryId,
+      subCategoryId: input.subCategoryId,
+      numberOfRepetitions: input.numberOfRepetitions,
+      frequency: input.frequency,
+    });
 
-    let datePtr = CustomDate.parseValue(payBefore);
-    const parsedStartDate = datePtr;
-    const serverDate = CustomDate.parseValue(new Date().toISOString());
-    const expensesArr = [];
-
-    const card =
-      cardId &&
-      (await Card.findOne({
-        where: {
-          id: cardId,
-          userId,
-        },
-      }));
-
-    const numberOfExpenses =
-      frequency === FixedExpenseFrequency.BIWEEKLY
-        ? differenceInWeeks(
-            calculateNumberOfBiWeeklyWeeks(
-              parsedStartDate,
-              numberOfMonthsOrWeeks
-            ),
-            datePtr
-          )
-        : differenceInMonths(
-            calculateNumberOfMonthWeeks(parsedStartDate, numberOfMonthsOrWeeks),
-            datePtr
-          );
-
-    for (let i = 0; i < numberOfExpenses; i++) {
-      expensesArr.push({
-        userId,
-        concept,
-        total,
-        comments: comment,
-        category: categoryAdapter(category),
-        payBefore: datePtr,
-        cardId: card?.id,
-        createdAt: serverDate,
-        updatedAt: serverDate,
-      });
-      datePtr =
-        frequency === FixedExpenseFrequency.BIWEEKLY
-          ? addDays(datePtr, 15)
-          : addMonths(datePtr, 1);
-    }
-
-    const expensesList = await Expense.bulkCreate(expensesArr);
-    logger.info(`${expensesList.length} Expenses were created ${frequency}`);
-
-    return expensesList.map((expense) => adaptExpensesWithCard(expense, card));
+    return expenses.map((expense) => adaptExpensesDTOInput(expense));
   };

--- a/src/service/expenses-service.ts
+++ b/src/service/expenses-service.ts
@@ -1,17 +1,35 @@
+import { addDays, addMonths } from 'date-fns';
 import { FindOptions, Sequelize } from 'sequelize';
 import { ExpenseDTO } from '../dto';
+import { FixedExpenseFrequency } from '../generated/graphql.js';
 import { ExpenseRepository } from '../repository/expense-repository.js';
 import { logger } from '../logger.js';
-import { PeriodRepository } from '../repository/period-repository.js';
+import {
+  FORTNIGHTLY_NUMBER_OF_DAYS,
+  PeriodRepository,
+} from '../repository/period-repository.js';
 
 export type ExpenseInput = {
   concept: string;
   total: number;
   cardId?: string;
   periodId: string;
+  payBefore?: Date;
   comments?: string;
   categoryId: string;
   subCategoryId: string;
+};
+
+export type FixedExpenseInput = {
+  concept: string;
+  total: number;
+  cardId?: string;
+  payBefore: Date;
+  comment?: string;
+  categoryId: string;
+  subCategoryId: string;
+  numberOfRepetitions: number;
+  frequency: FixedExpenseFrequency;
 };
 
 export class ExpensesService {
@@ -160,6 +178,60 @@ export class ExpensesService {
 
   async getExpenseById(id: string) {
     return this.expenseRepository.getExpenseByPK(id);
+  }
+
+  async createFixedExpenses(input: FixedExpenseInput) {
+    const transaction = await this.sequelize.transaction();
+    try {
+      const expenses: ExpenseDTO[] = [];
+      const baseDate = input.payBefore;
+
+      for (let i = 0; i < input.numberOfRepetitions; i++) {
+        const targetDate =
+          input.frequency === FixedExpenseFrequency.MONTHLY
+            ? addMonths(baseDate, i)
+            : addDays(baseDate, FORTNIGHTLY_NUMBER_OF_DAYS * i);
+
+        let period = await this.periodRepository.getPeriodBy(
+          { date: targetDate },
+          { transaction }
+        );
+
+        if (!period) {
+          const created = await this.periodRepository.createPeriod(
+            targetDate,
+            { transaction }
+          );
+          period = { id: created.id } as any;
+        }
+
+        const expense = await this.expenseRepository.createExpense(
+          {
+            concept: input.concept,
+            total: input.total,
+            cardId: input.cardId,
+            periodId: period.id,
+            categoryId: input.categoryId,
+            subCategoryId: input.subCategoryId,
+            comments: input.comment,
+            payBefore: targetDate,
+          },
+          { transaction }
+        );
+
+        expenses.push(expense);
+      }
+
+      await transaction.commit();
+      logger.info(
+        `Created ${expenses.length} fixed expenses (${input.frequency})`
+      );
+      return expenses;
+    } catch (error) {
+      await transaction.rollback();
+      logger.error('Error creating fixed expenses: ' + error.message);
+      throw error;
+    }
   }
 
   calculateTotal(expenses: ExpenseDTO[]) {

--- a/test/src/service/expenses-service.spec.ts
+++ b/test/src/service/expenses-service.spec.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Sequelize } from 'sequelize';
+import { ExpensesService } from '../../../src/service/expenses-service.js';
+import { FixedExpenseFrequency } from '../../../src/generated/graphql.js';
+
+const userId = 'test-user';
+let service: ExpensesService;
+
+const mockTransaction = {
+  commit: vi.fn(),
+  rollback: vi.fn(),
+};
+
+const mockSequelize = {
+  transaction: vi.fn().mockResolvedValue(mockTransaction),
+} as unknown as Sequelize;
+
+const basePeriod = {
+  id: 'period-1',
+  userId,
+  startDate: '2026-04-01',
+  endDate: '2026-04-14',
+};
+
+const baseFixedInput = {
+  concept: 'Rent',
+  total: 5000,
+  payBefore: new Date('2026-04-01T00:00:00Z'),
+  categoryId: 'cat-1',
+  subCategoryId: 'sub-1',
+  numberOfRepetitions: 3,
+  frequency: FixedExpenseFrequency.MONTHLY,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  service = new ExpensesService(userId, mockSequelize);
+});
+
+describe('createFixedExpenses', () => {
+  it('creates the correct number of monthly expenses', async () => {
+    const mockGetPeriodBy = vi.fn().mockResolvedValue(basePeriod);
+    const mockCreateExpense = vi.fn().mockImplementation((input) => ({
+      id: crypto.randomUUID(),
+      ...input,
+      userId,
+      card: null,
+      category: { id: input.categoryId, name: 'Test', subCategories: [{ id: input.subCategoryId, name: 'Sub' }] },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }));
+
+    (service as any).periodRepository = {
+      getPeriodBy: mockGetPeriodBy,
+      createPeriod: vi.fn(),
+    };
+    (service as any).expenseRepository = {
+      createExpense: mockCreateExpense,
+    };
+
+    const result = await service.createFixedExpenses(baseFixedInput);
+
+    expect(result).toHaveLength(3);
+    expect(mockCreateExpense).toHaveBeenCalledTimes(3);
+    expect(mockTransaction.commit).toHaveBeenCalled();
+    expect(mockTransaction.rollback).not.toHaveBeenCalled();
+  });
+
+  it('creates biweekly expenses with 15-day intervals', async () => {
+    const mockGetPeriodBy = vi.fn().mockResolvedValue(basePeriod);
+    const mockCreateExpense = vi.fn().mockImplementation((input) => ({
+      id: crypto.randomUUID(),
+      ...input,
+      userId,
+      card: null,
+      category: { id: input.categoryId, name: 'Test', subCategories: [{ id: input.subCategoryId, name: 'Sub' }] },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }));
+
+    (service as any).periodRepository = {
+      getPeriodBy: mockGetPeriodBy,
+      createPeriod: vi.fn(),
+    };
+    (service as any).expenseRepository = {
+      createExpense: mockCreateExpense,
+    };
+
+    await service.createFixedExpenses({
+      ...baseFixedInput,
+      frequency: FixedExpenseFrequency.BIWEEKLY,
+    });
+
+    const payBeforeDates = mockCreateExpense.mock.calls.map(
+      (call) => call[0].payBefore
+    );
+    expect(payBeforeDates[0].toISOString()).toBe('2026-04-01T00:00:00.000Z');
+    expect(payBeforeDates[1].toISOString()).toBe('2026-04-14T00:00:00.000Z');
+    expect(payBeforeDates[2].toISOString()).toBe('2026-04-27T00:00:00.000Z');
+  });
+
+  it('creates monthly expenses advancing by month', async () => {
+    const mockGetPeriodBy = vi.fn().mockResolvedValue(basePeriod);
+    const mockCreateExpense = vi.fn().mockImplementation((input) => ({
+      id: crypto.randomUUID(),
+      ...input,
+      userId,
+      card: null,
+      category: { id: input.categoryId, name: 'Test', subCategories: [{ id: input.subCategoryId, name: 'Sub' }] },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }));
+
+    (service as any).periodRepository = {
+      getPeriodBy: mockGetPeriodBy,
+      createPeriod: vi.fn(),
+    };
+    (service as any).expenseRepository = {
+      createExpense: mockCreateExpense,
+    };
+
+    await service.createFixedExpenses(baseFixedInput);
+
+    const payBeforeDates = mockCreateExpense.mock.calls.map(
+      (call) => call[0].payBefore
+    );
+    expect(payBeforeDates[0].toISOString()).toBe('2026-04-01T00:00:00.000Z');
+    expect(payBeforeDates[1].toISOString()).toBe('2026-05-01T00:00:00.000Z');
+    expect(payBeforeDates[2].toISOString()).toBe('2026-06-01T00:00:00.000Z');
+  });
+
+  it('creates periods when none exist for a target date', async () => {
+    const mockGetPeriodBy = vi.fn().mockResolvedValue(null);
+    const mockCreatePeriod = vi.fn().mockResolvedValue({ id: 'new-period' });
+    const mockCreateExpense = vi.fn().mockImplementation((input) => ({
+      id: crypto.randomUUID(),
+      ...input,
+      userId,
+      card: null,
+      category: { id: input.categoryId, name: 'Test', subCategories: [{ id: input.subCategoryId, name: 'Sub' }] },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }));
+
+    (service as any).periodRepository = {
+      getPeriodBy: mockGetPeriodBy,
+      createPeriod: mockCreatePeriod,
+    };
+    (service as any).expenseRepository = {
+      createExpense: mockCreateExpense,
+    };
+
+    await service.createFixedExpenses({
+      ...baseFixedInput,
+      numberOfRepetitions: 2,
+    });
+
+    expect(mockCreatePeriod).toHaveBeenCalledTimes(2);
+    expect(mockCreateExpense).toHaveBeenCalledTimes(2);
+
+    const periodIds = mockCreateExpense.mock.calls.map(
+      (call) => call[0].periodId
+    );
+    expect(periodIds).toEqual(['new-period', 'new-period']);
+  });
+
+  it('rolls back on error', async () => {
+    const mockGetPeriodBy = vi.fn().mockResolvedValue(basePeriod);
+    const mockCreateExpense = vi
+      .fn()
+      .mockRejectedValue(new Error('DB error'));
+
+    (service as any).periodRepository = {
+      getPeriodBy: mockGetPeriodBy,
+      createPeriod: vi.fn(),
+    };
+    (service as any).expenseRepository = {
+      createExpense: mockCreateExpense,
+    };
+
+    await expect(
+      service.createFixedExpenses(baseFixedInput)
+    ).rejects.toThrow('DB error');
+
+    expect(mockTransaction.rollback).toHaveBeenCalled();
+    expect(mockTransaction.commit).not.toHaveBeenCalled();
+  });
+
+  it('passes cardId when provided', async () => {
+    const mockGetPeriodBy = vi.fn().mockResolvedValue(basePeriod);
+    const mockCreateExpense = vi.fn().mockImplementation((input) => ({
+      id: crypto.randomUUID(),
+      ...input,
+      userId,
+      card: { id: input.cardId },
+      category: { id: input.categoryId, name: 'Test', subCategories: [{ id: input.subCategoryId, name: 'Sub' }] },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }));
+
+    (service as any).periodRepository = {
+      getPeriodBy: mockGetPeriodBy,
+      createPeriod: vi.fn(),
+    };
+    (service as any).expenseRepository = {
+      createExpense: mockCreateExpense,
+    };
+
+    await service.createFixedExpenses({
+      ...baseFixedInput,
+      numberOfRepetitions: 1,
+      cardId: 'card-123',
+    });
+
+    expect(mockCreateExpense.mock.calls[0][0].cardId).toBe('card-123');
+  });
+});


### PR DESCRIPTION
Modernize the createFixedExpense mutation to use categoryId/subCategoryId instead of the deprecated Category enum, and auto-resolve periods from payBefore dates. Periods now chain correctly from the previous period's endDate + 1 day instead of creating gaps.

- Update CreateFixedExpenseInput schema (categoryId, subCategoryId, numberOfRepetitions)
- Add createFixedExpenses to ExpensesService with transaction support
- Add transaction support to ExpenseRepository.createExpense
- Fix createPeriod to chain from the latest preceding period
- Extract FORTNIGHTLY_NUMBER_OF_DAYS as shared constant
- Add 6 tests for the new fixed expense logic